### PR TITLE
Set up and initialize an embedded h2 database by default

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,15 +53,17 @@ dependencies {
     exclude("club.minnced:opus-java")
   }
   implementation("org.jsoup:jsoup:1.10.2")
-  implementation("mysql:mysql-connector-java:8.0.18")
   implementation("org.apache.commons:commons-text:1.8")
   implementation("com.google.guava:guava:28.1-jre")
+
+  // Database drivers
+  implementation("mysql:mysql-connector-java:8.0.18")
+  implementation("com.h2database:h2:1.4.200")
 
   // Test dependencies
   testImplementation("org.springframework.boot:spring-boot-starter-test") {
     exclude("org.junit.vintage:junit-vintage-engine")
   }
-  testImplementation("com.h2database:h2:1.4.200")
 
   // Lombok
   compileOnly("org.projectlombok:lombok:1.18.10")

--- a/src/main/resources/application-default.properties
+++ b/src/main/resources/application-default.properties
@@ -1,0 +1,8 @@
+spring.datasource.username=kappabot
+spring.datasource.password=kappabot
+spring.datasource.url=jdbc:h2:mem:test;MODE=MYSQL;TRACE_LEVEL_FILE=0;IGNORECASE=TRUE;DATABASE_TO_LOWER=TRUE
+
+spring.jpa.hibernate.ddl-auto=create
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.initialization-mode=always
+spring.datasource.platform=h2

--- a/src/main/resources/application-mysql.properties
+++ b/src/main/resources/application-mysql.properties
@@ -1,0 +1,9 @@
+spring.datasource.username=
+spring.datasource.password=
+spring.datasource.url=
+
+spring.jpa.hibernate.ddl-auto=none
+spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
+spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+spring.datasource.initialization-mode=never
+spring.datasource.platform=mysql

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,4 @@
-spring.datasource.initialization-mode=never
-
-spring.jpa.hibernate.ddl-auto=none
 spring.jpa.hibernate.naming.physical-strategy=com.gorlah.kappabot.jpa.strategy.CustomPhysicalNamingStrategy
-spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
 
 kb.user-agent=KappaBot
 


### PR DESCRIPTION
This change causes the application to, by default, set up an in memory h2 database and load the data-h2.sql initialization data on startup.

Previously, the application would try to use mysql as the default data source which does not work without additional set up and configuration. Now it should work right out of the box with no set up, which will be useful for testing and evaluation purposes.

To continue using mysql, existing installations will need to start passing a program argument to add the "mysql" spring profile. 
```
--spring.profiles.active=mysql
```
Setting this profile will cause the "default" profile not to be loaded. 