### PR TITLE
Refactor response parsing and formatting

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,11 +1,11 @@
 <component name="ProjectCodeStyleConfiguration">
-    <code_scheme name="Project" version="173">
-        <JavaCodeStyleSettings>
-            <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="5000"/>
-            <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="3000"/>
-            <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
-                <value/>
-            </option>
-        </JavaCodeStyleSettings>
-    </code_scheme>
+  <code_scheme name="Project" version="173">
+    <JavaCodeStyleSettings>
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="5000" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="9" />
+      <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+        <value />
+      </option>
+    </JavaCodeStyleSettings>
+  </code_scheme>
 </component>

--- a/src/main/java/com/gorlah/kappabot/function/BotRequestEndpoint.java
+++ b/src/main/java/com/gorlah/kappabot/function/BotRequestEndpoint.java
@@ -1,0 +1,12 @@
+package com.gorlah.kappabot.function;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum BotRequestEndpoint {
+    DISCORD("Discord"),
+    REST("Rest");
+
+    @Getter private final String endpointName;
+}

--- a/src/main/java/com/gorlah/kappabot/function/BotRequestMetadata.java
+++ b/src/main/java/com/gorlah/kappabot/function/BotRequestMetadata.java
@@ -1,7 +1,6 @@
 package com.gorlah.kappabot.function;
 
-public interface BotRequestMetadata {
+public interface BotRequestMetadata extends SubstitutableMetadataFields {
 
-    String getAuthor();
     String getMessage();
 }

--- a/src/main/java/com/gorlah/kappabot/function/BotRequestMetadata.java
+++ b/src/main/java/com/gorlah/kappabot/function/BotRequestMetadata.java
@@ -4,5 +4,6 @@ public interface BotRequestMetadata {
 
     String getAuthor();
     String getAuthorMention();
+    BotRequestEndpoint getEndpoint();
     String getMessage();
 }

--- a/src/main/java/com/gorlah/kappabot/function/BotRequestMetadata.java
+++ b/src/main/java/com/gorlah/kappabot/function/BotRequestMetadata.java
@@ -1,6 +1,8 @@
 package com.gorlah.kappabot.function;
 
-public interface BotRequestMetadata extends SubstitutableMetadataFields {
+public interface BotRequestMetadata {
 
+    String getAuthor();
+    String getAuthorMention();
     String getMessage();
 }

--- a/src/main/java/com/gorlah/kappabot/function/BotResponseFormatter.java
+++ b/src/main/java/com/gorlah/kappabot/function/BotResponseFormatter.java
@@ -4,47 +4,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.text.StringSubstitutor;
 import org.springframework.stereotype.Component;
 
-import java.beans.IntrospectionException;
-import java.beans.Introspector;
-import java.beans.PropertyDescriptor;
-import java.lang.reflect.InvocationTargetException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Component
 public class BotResponseFormatter {
 
     public String format(String response, BotRequestMetadata metadata) {
-        return StringSubstitutor.replace(response, getPropertyReplacementMap(metadata));
-    }
-
-    private Map<String, String> getPropertyReplacementMap(BotRequestMetadata metadata) {
-        return getPropertyDescriptorsFromMetadata().stream()
-                .filter(property -> !"class".equals(property.getName()))
-                .collect(Collectors.toMap(PropertyDescriptor::getName, pd -> getValueForReplacement(pd, metadata)));
-    }
-
-    private List<PropertyDescriptor> getPropertyDescriptorsFromMetadata() {
-        try {
-            return Arrays.asList(Introspector.getBeanInfo(SubstitutableMetadataFields.class).getPropertyDescriptors());
-        } catch (IntrospectionException e) {
-            log.error(e.getMessage(), e);
-        }
-
-        return Collections.emptyList();
-    }
-
-    private String getValueForReplacement(PropertyDescriptor propertyDescriptor, BotRequestMetadata metadata) {
-        try {
-            return (String) propertyDescriptor.getReadMethod().invoke(metadata);
-        } catch (IllegalAccessException | InvocationTargetException e) {
-            log.error(e.getMessage(), e);
-        }
-
-        return propertyDescriptor.getName();
+        return StringSubstitutor.replace(response, Map.of("authorMention", metadata.getAuthorMention()));
     }
 }

--- a/src/main/java/com/gorlah/kappabot/function/BotResponseFormatter.java
+++ b/src/main/java/com/gorlah/kappabot/function/BotResponseFormatter.java
@@ -1,0 +1,50 @@
+package com.gorlah.kappabot.function;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.text.StringSubstitutor;
+import org.springframework.stereotype.Component;
+
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class BotResponseFormatter {
+
+    public String format(String response, BotRequestMetadata metadata) {
+        return StringSubstitutor.replace(response, getPropertyReplacementMap(metadata));
+    }
+
+    private Map<String, String> getPropertyReplacementMap(BotRequestMetadata metadata) {
+        return getPropertyDescriptorsFromMetadata().stream()
+                .filter(property -> !"class".equals(property.getName()))
+                .collect(Collectors.toMap(PropertyDescriptor::getName, pd -> getValueForReplacement(pd, metadata)));
+    }
+
+    private List<PropertyDescriptor> getPropertyDescriptorsFromMetadata() {
+        try {
+            return Arrays.asList(Introspector.getBeanInfo(SubstitutableMetadataFields.class).getPropertyDescriptors());
+        } catch (IntrospectionException e) {
+            log.error(e.getMessage(), e);
+        }
+
+        return Collections.emptyList();
+    }
+
+    private String getValueForReplacement(PropertyDescriptor propertyDescriptor, BotRequestMetadata metadata) {
+        try {
+            return (String) propertyDescriptor.getReadMethod().invoke(metadata);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            log.error(e.getMessage(), e);
+        }
+
+        return propertyDescriptor.getName();
+    }
+}

--- a/src/main/java/com/gorlah/kappabot/function/FunctionProcessor.java
+++ b/src/main/java/com/gorlah/kappabot/function/FunctionProcessor.java
@@ -1,5 +1,6 @@
 package com.gorlah.kappabot.function;
 
+import com.gorlah.kappabot.message.ResponseMarkdownReplacer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -11,13 +12,15 @@ import java.util.stream.Collectors;
 public class FunctionProcessor {
 
     private final Set<BotFunction> botFunctions;
-    private final BotResponseFormatter responseFormatter;
+    private final ResponseMetadataReplacer metadataReplacer;
+    private final ResponseMarkdownReplacer markdownReplacer;
 
     public String process(BotRequestMetadata metadata) {
         return botFunctions.stream()
                 .filter(botFunction -> botFunction.shouldProcess(metadata.getMessage()))
                 .map(botFunction -> botFunction.process(metadata))
-                .map(response -> responseFormatter.format(response, metadata))
+                .map(response -> metadataReplacer.replace(response, metadata))
+                .map(response -> markdownReplacer.replace(response, metadata.getEndpoint()))
                 .collect(Collectors.joining("\n"));
     }
 }

--- a/src/main/java/com/gorlah/kappabot/function/FunctionProcessor.java
+++ b/src/main/java/com/gorlah/kappabot/function/FunctionProcessor.java
@@ -11,11 +11,13 @@ import java.util.stream.Collectors;
 public class FunctionProcessor {
 
     private final Set<BotFunction> botFunctions;
+    private final BotResponseFormatter responseFormatter;
 
     public String process(BotRequestMetadata metadata) {
         return botFunctions.stream()
                 .filter(botFunction -> botFunction.shouldProcess(metadata.getMessage()))
                 .map(botFunction -> botFunction.process(metadata))
+                .map(response -> responseFormatter.format(response, metadata))
                 .collect(Collectors.joining("\n"));
     }
 }

--- a/src/main/java/com/gorlah/kappabot/function/ResponseMetadataReplacer.java
+++ b/src/main/java/com/gorlah/kappabot/function/ResponseMetadataReplacer.java
@@ -1,16 +1,14 @@
 package com.gorlah.kappabot.function;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.text.StringSubstitutor;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
 
-@Slf4j
 @Component
-public class BotResponseFormatter {
+public class ResponseMetadataReplacer {
 
-    public String format(String response, BotRequestMetadata metadata) {
+    public String replace(String response, BotRequestMetadata metadata) {
         return StringSubstitutor.replace(response, Map.of("authorMention", metadata.getAuthorMention()));
     }
 }

--- a/src/main/java/com/gorlah/kappabot/function/SubstitutableMetadataFields.java
+++ b/src/main/java/com/gorlah/kappabot/function/SubstitutableMetadataFields.java
@@ -1,8 +1,0 @@
-package com.gorlah.kappabot.function;
-
-
-public interface SubstitutableMetadataFields {
-
-    String getAuthor();
-    String getAuthorMention();
-}

--- a/src/main/java/com/gorlah/kappabot/function/SubstitutableMetadataFields.java
+++ b/src/main/java/com/gorlah/kappabot/function/SubstitutableMetadataFields.java
@@ -1,0 +1,8 @@
+package com.gorlah.kappabot.function;
+
+
+public interface SubstitutableMetadataFields {
+
+    String getAuthor();
+    String getAuthorMention();
+}

--- a/src/main/java/com/gorlah/kappabot/integration/discord/DiscordBot.java
+++ b/src/main/java/com/gorlah/kappabot/integration/discord/DiscordBot.java
@@ -9,14 +9,11 @@ import net.dv8tion.jda.api.JDABuilder;
 import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
-import org.apache.commons.text.StringSubstitutor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
 import javax.security.auth.login.LoginException;
-import java.util.HashMap;
-import java.util.Map;
 
 @Slf4j
 @Component
@@ -50,19 +47,8 @@ public class DiscordBot extends ListenerAdapter {
             return;
         }
 
-        event.getChannel().sendMessage(processMessageEvent(event)).queue();
-    }
-
-    private String processMessageEvent(MessageReceivedEvent event) {
-        return formatResponse(functionProcessor.process(new DiscordRequestMetadata(event)), event);
-    }
-
-    private String formatResponse(String response, MessageReceivedEvent event) {
-        Map<String, String> values = new HashMap<>();
-
-        values.put("user.name", event.getMessage().getAuthor().getName());
-        values.put("user.mention", event.getMessage().getAuthor().getAsMention());
-
-        return StringSubstitutor.replace(response, values);
+        event.getChannel()
+                .sendMessage(functionProcessor.process(new DiscordRequestMetadata(event)))
+                .queue();
     }
 }

--- a/src/main/java/com/gorlah/kappabot/integration/discord/DiscordMarkdownFormatter.java
+++ b/src/main/java/com/gorlah/kappabot/integration/discord/DiscordMarkdownFormatter.java
@@ -1,0 +1,155 @@
+package com.gorlah.kappabot.integration.discord;
+
+import com.gorlah.kappabot.function.BotRequestEndpoint;
+import com.gorlah.kappabot.message.EndpointMarkdownFormatter;
+import com.gorlah.kappabot.message.AbstractMarkdownFormatter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DiscordMarkdownFormatter extends AbstractMarkdownFormatter implements EndpointMarkdownFormatter {
+
+    @Override
+    public String getItalicsBegin() {
+        return "*";
+    }
+
+    @Override
+    public String getItalicsEnd() {
+        return "*";
+    }
+
+    @Override
+    public String getBoldBegin() {
+        return "**";
+    }
+
+    @Override
+    public String getBoldEnd() {
+        return "**";
+    }
+
+    @Override
+    public String getBoldItalicsBegin() {
+        return "***";
+    }
+
+    @Override
+    public String getBoldItalicsEnd() {
+        return "***";
+    }
+
+    @Override
+    public String getUnderlineBegin() {
+        return "__";
+    }
+
+    @Override
+    public String getUnderlineEnd() {
+        return "__";
+    }
+
+    @Override
+    public String getUnderlineItalicsBegin() {
+        return "__*";
+    }
+
+    @Override
+    public String getUnderlineItalicsEnd() {
+        return "*__";
+    }
+
+    @Override
+    public String getUnderlineBoldBegin() {
+        return "__**";
+    }
+
+    @Override
+    public String getUnderlineBoldEnd() {
+        return "**__";
+    }
+
+    @Override
+    public String getUnderlineBoldItalicsBegin() {
+        return "__***";
+    }
+
+    @Override
+    public String getUnderlineBoldItalicsEnd() {
+        return "***__";
+    }
+
+    @Override
+    public String getStrikethroughBegin() {
+        return "~~";
+    }
+
+    @Override
+    public String getStrikethroughEnd() {
+        return "~~";
+    }
+
+    @Override
+    public String getCodeBegin() {
+        return "`";
+    }
+
+    @Override
+    public String getCodeEnd() {
+        return "`";
+    }
+
+    @Override
+    public String getCodeBlockBegin() {
+        return "```";
+    }
+
+    @Override
+    public String getCodeBlockEnd() {
+        return "```";
+    }
+
+    @Override
+    public String getCodeBlockWithLanguageBegin(String language) {
+        return "```" + language + "\n";
+    }
+
+    @Override
+    public String getCodeBlockWithLanguageEnd(String language) {
+        return "```";
+    }
+
+    @Override
+    public String getQuoteBegin() {
+        return "> ";
+    }
+
+    @Override
+    public String getQuoteEnd() {
+        return "";
+    }
+
+    @Override
+    public String getQuoteBlockBegin() {
+        return ">>> ";
+    }
+
+    @Override
+    public String getQuoteBlockEnd() {
+        return "";
+    }
+
+    @Override
+    public String getSpoilerBegin() {
+        return "||";
+    }
+
+    @Override
+    public String getSpoilerEnd() {
+        return "||";
+    }
+
+    @Override
+    public BotRequestEndpoint getFormatterFor() {
+        return BotRequestEndpoint.DISCORD;
+    }
+}

--- a/src/main/java/com/gorlah/kappabot/integration/discord/DiscordRequestMetadata.java
+++ b/src/main/java/com/gorlah/kappabot/integration/discord/DiscordRequestMetadata.java
@@ -8,10 +8,12 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 public class DiscordRequestMetadata implements BotRequestMetadata {
 
     private final String author;
+    private final String authorMention;
     private final String message;
 
     DiscordRequestMetadata(MessageReceivedEvent event) {
         this.author = event.getAuthor().getName();
+        this.authorMention = event.getAuthor().getAsMention();
         this.message = event.getMessage().getContentRaw();
     }
 }

--- a/src/main/java/com/gorlah/kappabot/integration/discord/DiscordRequestMetadata.java
+++ b/src/main/java/com/gorlah/kappabot/integration/discord/DiscordRequestMetadata.java
@@ -1,5 +1,6 @@
 package com.gorlah.kappabot.integration.discord;
 
+import com.gorlah.kappabot.function.BotRequestEndpoint;
 import com.gorlah.kappabot.function.BotRequestMetadata;
 import lombok.Value;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
@@ -15,5 +16,10 @@ public class DiscordRequestMetadata implements BotRequestMetadata {
         this.author = event.getAuthor().getName();
         this.authorMention = event.getAuthor().getAsMention();
         this.message = event.getMessage().getContentRaw();
+    }
+
+    @Override
+    public BotRequestEndpoint getEndpoint() {
+        return BotRequestEndpoint.DISCORD;
     }
 }

--- a/src/main/java/com/gorlah/kappabot/message/AbstractMarkdownFormatter.java
+++ b/src/main/java/com/gorlah/kappabot/message/AbstractMarkdownFormatter.java
@@ -1,0 +1,48 @@
+package com.gorlah.kappabot.message;
+
+import java.util.Map;
+
+import static com.gorlah.kappabot.message.MarkdownVariables.*;
+
+public abstract class AbstractMarkdownFormatter implements MarkdownFormatter {
+
+    private final Map<String, String> formatterMap;
+
+    public AbstractMarkdownFormatter() {
+        this.formatterMap = Map.ofEntries(
+                Map.entry(ITALICS_BEGIN_VAR, getItalicsBegin()),
+                Map.entry(ITALICS_END_VAR, getItalicsEnd()),
+                Map.entry(BOLD_BEGIN_VAR, getBoldBegin()),
+                Map.entry(BOLD_END_VAR, getBoldEnd()),
+                Map.entry(BOLD_ITALICS_BEGIN_VAR, getBoldItalicsBegin()),
+                Map.entry(BOLD_ITALICS_END_VAR, getBoldItalicsEnd()),
+                Map.entry(UNDERLINE_BEGIN_VAR, getUnderlineBegin()),
+                Map.entry(UNDERLINE_END_VAR, getUnderlineEnd()),
+                Map.entry(UNDERLINE_ITALICS_BEGIN_VAR, getUnderlineItalicsBegin()),
+                Map.entry(UNDERLINE_ITALICS_END_VAR, getUnderlineItalicsEnd()),
+                Map.entry(UNDERLINE_BOLD_BEGIN_VAR, getUnderlineBoldBegin()),
+                Map.entry(UNDERLINE_BOLD_END_VAR, getUnderlineBoldEnd()),
+                Map.entry(UNDERLINE_BOLD_ITALICS_BEGIN_VAR, getUnderlineBoldItalicsBegin()),
+                Map.entry(UNDERLINE_BOLD_ITALICS_END_VAR, getUnderlineBoldItalicsEnd()),
+                Map.entry(STRIKETHROUGH_BEGIN_VAR, getStrikethroughBegin()),
+                Map.entry(STRIKETHROUGH_END_VAR, getStrikethroughEnd()),
+                Map.entry(CODE_BEGIN_VAR, getCodeBegin()),
+                Map.entry(CODE_END_VAR, getCodeEnd()),
+                Map.entry(CODE_BLOCK_BEGIN_VAR, getCodeBlockBegin()),
+                Map.entry(CODE_BLOCK_END_VAR, getCodeBlockEnd()),
+                Map.entry(CODE_BLOCK_LANGUAGE_BEGIN_VAR, getCodeBlockWithLanguageBegin("Java")),
+                Map.entry(CODE_BLOCK_LANGUAGE_END_VAR, getCodeBlockWithLanguageEnd("Java")),
+                Map.entry(QUOTE_BEGIN_VAR, getQuoteBegin()),
+                Map.entry(QUOTE_END_VAR, getQuoteEnd()),
+                Map.entry(QUOTE_BLOCK_BEGIN_VAR, getQuoteBlockBegin()),
+                Map.entry(QUOTE_BLOCK_END_VAR, getQuoteBlockEnd()),
+                Map.entry(SPOILER_BEGIN_VAR, getSpoilerBegin()),
+                Map.entry(SPOILER_END_VAR, getSpoilerEnd())
+        );
+    }
+
+    @Override
+    public Map<String, String> getFormatterMap() {
+        return formatterMap;
+    }
+}

--- a/src/main/java/com/gorlah/kappabot/message/DefaultMarkdownFormatter.java
+++ b/src/main/java/com/gorlah/kappabot/message/DefaultMarkdownFormatter.java
@@ -1,0 +1,147 @@
+package com.gorlah.kappabot.message;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class DefaultMarkdownFormatter extends AbstractMarkdownFormatter {
+
+    @Override
+    public String getItalicsBegin() {
+        return "";
+    }
+
+    @Override
+    public String getItalicsEnd() {
+        return "";
+    }
+
+    @Override
+    public String getBoldBegin() {
+        return "";
+    }
+
+    @Override
+    public String getBoldEnd() {
+        return "";
+    }
+
+    @Override
+    public String getBoldItalicsBegin() {
+        return "";
+    }
+
+    @Override
+    public String getBoldItalicsEnd() {
+        return "";
+    }
+
+    @Override
+    public String getUnderlineBegin() {
+        return "";
+    }
+
+    @Override
+    public String getUnderlineEnd() {
+        return "";
+    }
+
+    @Override
+    public String getUnderlineItalicsBegin() {
+        return "";
+    }
+
+    @Override
+    public String getUnderlineItalicsEnd() {
+        return "";
+    }
+
+    @Override
+    public String getUnderlineBoldBegin() {
+        return "";
+    }
+
+    @Override
+    public String getUnderlineBoldEnd() {
+        return "";
+    }
+
+    @Override
+    public String getUnderlineBoldItalicsBegin() {
+        return "";
+    }
+
+    @Override
+    public String getUnderlineBoldItalicsEnd() {
+        return "";
+    }
+
+    @Override
+    public String getStrikethroughBegin() {
+        return "";
+    }
+
+    @Override
+    public String getStrikethroughEnd() {
+        return "";
+    }
+
+    @Override
+    public String getCodeBegin() {
+        return "";
+    }
+
+    @Override
+    public String getCodeEnd() {
+        return "";
+    }
+
+    @Override
+    public String getCodeBlockBegin() {
+        return "";
+    }
+
+    @Override
+    public String getCodeBlockEnd() {
+        return "";
+    }
+
+    @Override
+    public String getCodeBlockWithLanguageBegin(String language) {
+        return "";
+    }
+
+    @Override
+    public String getCodeBlockWithLanguageEnd(String language) {
+        return "";
+    }
+
+    @Override
+    public String getQuoteBegin() {
+        return "";
+    }
+
+    @Override
+    public String getQuoteEnd() {
+        return "";
+    }
+
+    @Override
+    public String getQuoteBlockBegin() {
+        return "";
+    }
+
+    @Override
+    public String getQuoteBlockEnd() {
+        return "";
+    }
+
+    @Override
+    public String getSpoilerBegin() {
+        return "";
+    }
+
+    @Override
+    public String getSpoilerEnd() {
+        return "";
+    }
+}

--- a/src/main/java/com/gorlah/kappabot/message/EndpointMarkdownFormatter.java
+++ b/src/main/java/com/gorlah/kappabot/message/EndpointMarkdownFormatter.java
@@ -1,0 +1,8 @@
+package com.gorlah.kappabot.message;
+
+import com.gorlah.kappabot.function.BotRequestEndpoint;
+
+public interface EndpointMarkdownFormatter extends MarkdownFormatter {
+
+    BotRequestEndpoint getFormatterFor();
+}

--- a/src/main/java/com/gorlah/kappabot/message/MarkdownFormatter.java
+++ b/src/main/java/com/gorlah/kappabot/message/MarkdownFormatter.java
@@ -1,0 +1,50 @@
+package com.gorlah.kappabot.message;
+
+import java.util.Map;
+
+public interface MarkdownFormatter {
+
+    String getItalicsBegin();
+    String getItalicsEnd();
+
+    String getBoldBegin();
+    String getBoldEnd();
+
+    String getBoldItalicsBegin();
+    String getBoldItalicsEnd();
+
+    String getUnderlineBegin();
+    String getUnderlineEnd();
+
+    String getUnderlineItalicsBegin();
+    String getUnderlineItalicsEnd();
+
+    String getUnderlineBoldBegin();
+    String getUnderlineBoldEnd();
+
+    String getUnderlineBoldItalicsBegin();
+    String getUnderlineBoldItalicsEnd();
+
+    String getStrikethroughBegin();
+    String getStrikethroughEnd();
+
+    String getCodeBegin();
+    String getCodeEnd();
+
+    String getCodeBlockBegin();
+    String getCodeBlockEnd();
+
+    String getCodeBlockWithLanguageBegin(String language);
+    String getCodeBlockWithLanguageEnd(String language);
+
+    String getQuoteBegin();
+    String getQuoteEnd();
+
+    String getQuoteBlockBegin();
+    String getQuoteBlockEnd();
+
+    String getSpoilerBegin();
+    String getSpoilerEnd();
+
+    Map<String, String> getFormatterMap();
+}

--- a/src/main/java/com/gorlah/kappabot/message/MarkdownVariables.java
+++ b/src/main/java/com/gorlah/kappabot/message/MarkdownVariables.java
@@ -1,0 +1,69 @@
+package com.gorlah.kappabot.message;
+
+public class MarkdownVariables {
+
+    protected static final String ITALICS_BEGIN_VAR                 = "markdown.italics.begin";
+    protected static final String ITALICS_END_VAR                   = "markdown.italics.end";
+    protected static final String BOLD_BEGIN_VAR                    = "markdown.bold.begin";
+    protected static final String BOLD_END_VAR                      = "markdown.bold.end";
+    protected static final String BOLD_ITALICS_BEGIN_VAR            = "markdown.bolditalics.begin";
+    protected static final String BOLD_ITALICS_END_VAR              = "markdown.bolditalics.end";
+    protected static final String UNDERLINE_BEGIN_VAR               = "markdown.underline.begin";
+    protected static final String UNDERLINE_END_VAR                 = "markdown.underline.end";
+    protected static final String UNDERLINE_ITALICS_BEGIN_VAR       = "markdown.underlineitalics.begin";
+    protected static final String UNDERLINE_ITALICS_END_VAR         = "markdown.underlineitalics.end";
+    protected static final String UNDERLINE_BOLD_BEGIN_VAR          = "markdown.underlinebold.begin";
+    protected static final String UNDERLINE_BOLD_END_VAR            = "markdown.underlinebold.end";
+    protected static final String UNDERLINE_BOLD_ITALICS_BEGIN_VAR  = "markdown.underlinebolditalics.begin";
+    protected static final String UNDERLINE_BOLD_ITALICS_END_VAR    = "markdown.underlinebolditalics.end";
+    protected static final String STRIKETHROUGH_BEGIN_VAR           = "markdown.strikethrough.begin";
+    protected static final String STRIKETHROUGH_END_VAR             = "markdown.strikethrough.end";
+    protected static final String CODE_BEGIN_VAR                    = "markdown.code.begin";
+    protected static final String CODE_END_VAR                      = "markdown.code.end";
+    protected static final String CODE_BLOCK_BEGIN_VAR              = "markdown.codeblock.begin";
+    protected static final String CODE_BLOCK_END_VAR                = "markdown.codeblock.end";
+    protected static final String CODE_BLOCK_LANGUAGE_BEGIN_VAR     = "markdown.codeblocklanguage.begin";
+    protected static final String CODE_BLOCK_LANGUAGE_END_VAR       = "markdown.codeblocklanguage.end";
+    protected static final String QUOTE_BEGIN_VAR                   = "markdown.quote.begin";
+    protected static final String QUOTE_END_VAR                     = "markdown.quote.end";
+    protected static final String QUOTE_BLOCK_BEGIN_VAR             = "markdown.quoteblock.begin";
+    protected static final String QUOTE_BLOCK_END_VAR               = "markdown.quoteblock.end";
+    protected static final String SPOILER_BEGIN_VAR                 = "markdown.spoiler.begin";
+    protected static final String SPOILER_END_VAR                   = "markdown.spoiler.end";
+
+    protected static final String PREFIX                    = "${";
+    protected static final String SUFFIX                    = "}";
+
+    public static final String ITALICS_BEGIN                = PREFIX + ITALICS_BEGIN_VAR                + SUFFIX;
+    public static final String ITALICS_END                  = PREFIX + ITALICS_END_VAR                  + SUFFIX;
+    public static final String BOLD_BEGIN                   = PREFIX + BOLD_BEGIN_VAR                   + SUFFIX;
+    public static final String BOLD_END                     = PREFIX + BOLD_END_VAR                     + SUFFIX;
+    public static final String BOLD_ITALICS_BEGIN           = PREFIX + BOLD_ITALICS_BEGIN_VAR           + SUFFIX;
+    public static final String BOLD_ITALICS_END             = PREFIX + BOLD_ITALICS_END_VAR             + SUFFIX;
+    public static final String UNDERLINE_BEGIN              = PREFIX + UNDERLINE_BEGIN_VAR              + SUFFIX;
+    public static final String UNDERLINE_END                = PREFIX + UNDERLINE_END_VAR                + SUFFIX;
+    public static final String UNDERLINE_ITALICS_BEGIN      = PREFIX + UNDERLINE_ITALICS_BEGIN_VAR      + SUFFIX;
+    public static final String UNDERLINE_ITALICS_END        = PREFIX + UNDERLINE_ITALICS_END_VAR        + SUFFIX;
+    public static final String UNDERLINE_BOLD_BEGIN         = PREFIX + UNDERLINE_BOLD_BEGIN_VAR         + SUFFIX;
+    public static final String UNDERLINE_BOLD_END           = PREFIX + UNDERLINE_BOLD_END_VAR           + SUFFIX;
+    public static final String UNDERLINE_BOLD_ITALICS_BEGIN = PREFIX + UNDERLINE_BOLD_ITALICS_BEGIN_VAR + SUFFIX;
+    public static final String UNDERLINE_BOLD_ITALICS_END   = PREFIX + UNDERLINE_BOLD_ITALICS_END_VAR   + SUFFIX;
+    public static final String STRIKETHROUGH_BEGIN          = PREFIX + STRIKETHROUGH_BEGIN_VAR          + SUFFIX;
+    public static final String STRIKETHROUGH_END            = PREFIX + STRIKETHROUGH_END_VAR            + SUFFIX;
+    public static final String CODE_BEGIN                   = PREFIX + CODE_BEGIN_VAR                   + SUFFIX;
+    public static final String CODE_END                     = PREFIX + CODE_END_VAR                     + SUFFIX;
+    public static final String CODE_BLOCK_BEGIN             = PREFIX + CODE_BLOCK_BEGIN_VAR             + SUFFIX;
+    public static final String CODE_BLOCK_END               = PREFIX + CODE_BLOCK_END_VAR               + SUFFIX;
+    public static final String CODE_BLOCK_LANGUAGE_BEGIN    = PREFIX + CODE_BLOCK_LANGUAGE_BEGIN_VAR    + SUFFIX;
+    public static final String CODE_BLOCK_LANGUAGE_END      = PREFIX + CODE_BLOCK_LANGUAGE_END_VAR      + SUFFIX;
+    public static final String QUOTE_BEGIN                  = PREFIX + QUOTE_BEGIN_VAR                  + SUFFIX;
+    public static final String QUOTE_END                    = PREFIX + QUOTE_END_VAR                    + SUFFIX;
+    public static final String QUOTE_BLOCK_BEGIN            = PREFIX + QUOTE_BLOCK_BEGIN_VAR            + SUFFIX;
+    public static final String QUOTE_BLOCK_END              = PREFIX + QUOTE_BLOCK_END_VAR              + SUFFIX;
+    public static final String SPOILER_BEGIN                = PREFIX + SPOILER_BEGIN_VAR                + SUFFIX;
+    public static final String SPOILER_END                  = PREFIX + SPOILER_END_VAR                  + SUFFIX;
+
+    private MarkdownVariables() {
+
+    }
+}

--- a/src/main/java/com/gorlah/kappabot/message/ResponseMarkdownReplacer.java
+++ b/src/main/java/com/gorlah/kappabot/message/ResponseMarkdownReplacer.java
@@ -1,0 +1,34 @@
+package com.gorlah.kappabot.message;
+
+import com.gorlah.kappabot.function.BotRequestEndpoint;
+import org.apache.commons.text.StringSubstitutor;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Set;
+
+import static com.gorlah.kappabot.message.MarkdownVariables.*;
+import static java.util.stream.Collectors.toMap;
+
+@Component
+public class ResponseMarkdownReplacer {
+
+    private final Map<BotRequestEndpoint, Map<String, String>> replacerMaps;
+    private final DefaultMarkdownFormatter defaultMarkdownFormatter;
+
+    public ResponseMarkdownReplacer(Set<EndpointMarkdownFormatter> formatters,
+                                    DefaultMarkdownFormatter defaultMarkdownFormatter) {
+        this.replacerMaps = formatters.stream()
+                .collect(toMap(EndpointMarkdownFormatter::getFormatterFor,
+                        MarkdownFormatter::getFormatterMap));
+        this.defaultMarkdownFormatter = defaultMarkdownFormatter;
+    }
+
+    public String replace(String response, BotRequestEndpoint endpoint) {
+        return StringSubstitutor.replace(response, getMapOrDefault(endpoint), PREFIX, SUFFIX);
+    }
+
+    private Map<String, String> getMapOrDefault(BotRequestEndpoint endpoint) {
+        return replacerMaps.getOrDefault(endpoint, defaultMarkdownFormatter.getFormatterMap());
+    }
+}

--- a/src/main/java/com/gorlah/kappabot/rest/CommandService.java
+++ b/src/main/java/com/gorlah/kappabot/rest/CommandService.java
@@ -1,45 +1,24 @@
 package com.gorlah.kappabot.rest;
 
-import com.gorlah.kappabot.command.CommandProcessor;
 import com.gorlah.kappabot.function.FunctionProcessor;
 import com.gorlah.kappabot.rest.model.CommandRequest;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.text.StringSubstitutor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Objects;
 
 @Service
 @RestController
 @RequiredArgsConstructor
 public class CommandService {
 
-    @Value("${discord.command.prefix}")
-    private String commandPrefix;
-
-    private final CommandProcessor commandProcessor;
     private final FunctionProcessor functionProcessor;
 
     @PostMapping("/command/run")
     public String runCommand(@RequestBody CommandRequest request) {
-        if (request == null) {
-            throw new RuntimeException();
-        }
-
-        return formatResponse(functionProcessor.process(request), request.getAuthor());
-    }
-
-    private String formatResponse(String response, String author) {
-        Map<String, String> values = new HashMap<>();
-
-        values.put("user.name", author);
-        values.put("user.mention", author);
-
-        return StringSubstitutor.replace(response, values);
+        return functionProcessor.process(Objects.requireNonNull(request));
     }
 }

--- a/src/main/java/com/gorlah/kappabot/rest/model/CommandRequest.java
+++ b/src/main/java/com/gorlah/kappabot/rest/model/CommandRequest.java
@@ -6,6 +6,11 @@ import lombok.Value;
 @Value
 public class CommandRequest implements BotRequestMetadata {
 
-    private String author;
-    private String message;
+    private final String author;
+    private final String message;
+
+    @Override
+    public String getAuthorMention() {
+        return author;
+    }
 }

--- a/src/main/java/com/gorlah/kappabot/rest/model/CommandRequest.java
+++ b/src/main/java/com/gorlah/kappabot/rest/model/CommandRequest.java
@@ -1,5 +1,6 @@
 package com.gorlah.kappabot.rest.model;
 
+import com.gorlah.kappabot.function.BotRequestEndpoint;
 import com.gorlah.kappabot.function.BotRequestMetadata;
 import lombok.Value;
 
@@ -12,5 +13,10 @@ public class CommandRequest implements BotRequestMetadata {
     @Override
     public String getAuthorMention() {
         return author;
+    }
+
+    @Override
+    public BotRequestEndpoint getEndpoint() {
+        return BotRequestEndpoint.REST;
     }
 }

--- a/src/main/java/com/gorlah/kappabot/subcommand/AbstractCommand.java
+++ b/src/main/java/com/gorlah/kappabot/subcommand/AbstractCommand.java
@@ -54,7 +54,7 @@ public abstract class AbstractCommand implements Command {
 
     @Override
     public String getErrorText() {
-        return "Sorry, ${user.mention}. I ran into a problem processing your command.";
+        return "Sorry, ${authorMention}. I ran into a problem processing your command.";
     }
 
     @Override

--- a/src/main/java/com/gorlah/kappabot/subcommand/AbstractCommand.java
+++ b/src/main/java/com/gorlah/kappabot/subcommand/AbstractCommand.java
@@ -12,6 +12,11 @@ import java.util.Collections;
 import java.util.Objects;
 import java.util.TreeMap;
 
+import static com.gorlah.kappabot.message.MarkdownVariables.CODE_BEGIN;
+import static com.gorlah.kappabot.message.MarkdownVariables.CODE_BLOCK_BEGIN;
+import static com.gorlah.kappabot.message.MarkdownVariables.CODE_BLOCK_END;
+import static com.gorlah.kappabot.message.MarkdownVariables.CODE_END;
+
 public abstract class AbstractCommand implements Command {
 
     private TreeMap<String, Command> children = new TreeMap<>();
@@ -25,10 +30,11 @@ public abstract class AbstractCommand implements Command {
         StringBuilder builder = new StringBuilder(getHelpText());
 
         if (!children.isEmpty()) {
-            builder.append(" Try adding one of the following subcommands to `")
+            builder.append(" Try adding one of the following subcommands to ").append(CODE_BEGIN)
                     .append(getAbsoluteCommandString())
-                    .append("`:")
-                    .append("```");
+                    .append(CODE_END)
+                    .append(":")
+                    .append(CODE_BLOCK_BEGIN);
 
             int padding = children
                     .values()
@@ -46,7 +52,7 @@ public abstract class AbstractCommand implements Command {
                 }
             }
 
-            builder.append("```");
+            builder.append(CODE_BLOCK_END);
         }
 
         return builder.toString();
@@ -59,9 +65,9 @@ public abstract class AbstractCommand implements Command {
 
     @Override
     public String getIncorrectUsageText() {
-        StringBuilder builder = new StringBuilder("Try adding one of the following subcommands to `")
-                .append(getAbsoluteCommandString())
-                .append("`:");
+        StringBuilder builder = new StringBuilder("Try adding one of the following subcommands to ")
+                .append(CODE_BEGIN).append(getAbsoluteCommandString()).append(CODE_END)
+                .append(":");
 
         children.values().stream()
                 .filter(Command::isShownInHelp)
@@ -71,9 +77,8 @@ public abstract class AbstractCommand implements Command {
             builder.deleteCharAt(builder.length() - 1);
         }
 
-        builder.append("\nOr use `")
-                .append(getAbsoluteCommandString())
-                .append(" help`");
+        builder.append("\nOr use ").append(CODE_BEGIN).append(getAbsoluteCommandString()).append(" help")
+                .append(CODE_END);
 
         return builder.toString();
     }

--- a/src/main/java/com/gorlah/kappabot/subcommand/RootCommand.java
+++ b/src/main/java/com/gorlah/kappabot/subcommand/RootCommand.java
@@ -13,7 +13,7 @@ public class RootCommand extends AbstractCommand {
 
     @Override
     public String getHelpText() {
-        return "Hey, ${user.mention}! My name is KappaBot.";
+        return "Hey, ${authorMention}! My name is KappaBot.";
     }
 
     @Override

--- a/src/main/java/com/gorlah/kappabot/subcommand/root/HelloCommand.java
+++ b/src/main/java/com/gorlah/kappabot/subcommand/root/HelloCommand.java
@@ -30,9 +30,9 @@ public class HelloCommand extends AbstractCommand {
         val parameters = payload.getParameters();
 
         if (parameters != null && !parameters.isEmpty() && "there".equals(parameters.get(0))) {
-            return "General ${user.mention}!";
+            return "General ${authorMention}!";
         }
 
-        return "Hey, ${user.mention}!";
+        return "Hey, ${authorMention}!";
     }
 }

--- a/src/test/java/com/gorlah/kappabot/message/ResponseMarkdownReplacerTest.java
+++ b/src/test/java/com/gorlah/kappabot/message/ResponseMarkdownReplacerTest.java
@@ -1,0 +1,41 @@
+package com.gorlah.kappabot.message;
+
+import com.gorlah.kappabot.function.BotRequestEndpoint;
+import com.gorlah.kappabot.integration.discord.DiscordMarkdownFormatter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+class ResponseMarkdownReplacerTest {
+
+    private ResponseMarkdownReplacer markdownReplacer;
+
+    @BeforeEach
+    void setup() {
+        markdownReplacer = new ResponseMarkdownReplacer(Collections.singleton(new DiscordMarkdownFormatter()),
+                new DefaultMarkdownFormatter());
+    }
+
+    @Test
+    void testReplace() {
+        var exampleA = "${markdown.italics.begin}this is italic${markdown.italics.end}";
+        var expectedA = "*this is italic*";
+
+        var exampleB = "${markdown.bolditalics.begin}this is bold italics${markdown.bolditalics.end}";
+        var expectedB = "***this is bold italics***";
+
+        var exampleC = "${markdown.underline.begin}this is underlined${markdown.underline.end} and " +
+                "${markdown.strikethrough.begin}this is strikethrough${markdown.strikethrough.end}";
+        var expectedC = "__this is underlined__ and ~~this is strikethrough~~";
+
+        assertEquals(expectedA, markdownReplacer.replace(exampleA, BotRequestEndpoint.DISCORD));
+        assertEquals(expectedB, markdownReplacer.replace(exampleB, BotRequestEndpoint.DISCORD));
+        assertEquals(expectedC, markdownReplacer.replace(exampleC, BotRequestEndpoint.DISCORD));
+    }
+}


### PR DESCRIPTION
This PR is a work in progress...

The purpose of this pull request is to improve response parsing and code readability.  The main focus of these changes:

- Response formatting is now centralized to a single location and endpoints no longer need to worry about replacing properties.
- The properties that need to be replaced are automatically determined using reflection and a new interface called `SubstitutableMetadataFields`.  Any accessor methods defined here will automatically have their associated properties replaced in the response. For instance, the accessor method `getAuthorMention()` defined in `SubstitutableMetadataFields` will replace any occurrence of `${authorMention}` in the response. 