### PR TITLE
message transport specific response formatting

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,7 @@ tasks {
 }
 
 dependencies {
+    implementation("jakarta.inject:jakarta.inject-api:1.0")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.github.ben-manes.caffeine:caffeine:2.8.1")
@@ -55,6 +56,7 @@ dependencies {
     implementation("org.jsoup:jsoup:1.12.1")
     implementation("org.apache.commons:commons-text:1.8")
     implementation("com.google.guava:guava:28.2-jre")
+    implementation("com.atlassian.commonmark:commonmark:0.14.0")
 
     // Database drivers
     implementation("mysql:mysql-connector-java:8.0.19")

--- a/src/main/java/com/gorlah/kappabot/command/Command.java
+++ b/src/main/java/com/gorlah/kappabot/command/Command.java
@@ -43,10 +43,10 @@ public interface Command {
     void addChild(Command child);
 
     /**
-     * The method to call for processing this command.
+     * Processes a command.
      *
      * @param payload a payload containing information which may be useful or required for processing this command
-     * @return the text to display generated from this command
+     * @return the markdown formatted response from executing this command
      */
     String process(CommandPayload payload);
 }

--- a/src/main/java/com/gorlah/kappabot/function/BotFunction.java
+++ b/src/main/java/com/gorlah/kappabot/function/BotFunction.java
@@ -1,5 +1,7 @@
 package com.gorlah.kappabot.function;
 
+import com.gorlah.kappabot.function.response.BotResponse;
+
 import java.util.Optional;
 
 public interface BotFunction {
@@ -10,5 +12,5 @@ public interface BotFunction {
      * @param metadata metadata related to the bot request
      * @return the response based on the message
      */
-    Optional<String> process(BotRequestMetadata metadata);
+    Optional<BotResponse> process(BotRequestMetadata metadata);
 }

--- a/src/main/java/com/gorlah/kappabot/function/FunctionProcessor.java
+++ b/src/main/java/com/gorlah/kappabot/function/FunctionProcessor.java
@@ -1,22 +1,26 @@
 package com.gorlah.kappabot.function;
 
+import com.google.common.collect.ImmutableList;
+import com.gorlah.kappabot.function.response.formatter.BotResponseFormatter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
 public class FunctionProcessor {
 
     private final Set<BotFunction> botFunctions;
+    private final BotResponseFormatter botResponseFormatter;
 
-    public String process(BotRequestMetadata metadata) {
+    public List<String> process(BotRequestMetadata metadata) {
         return botFunctions.stream()
                 .map(botFunction -> botFunction.process(metadata))
                 .flatMap(Optional::stream)
-                .collect(Collectors.joining("\n"));
+                .map(response -> botResponseFormatter.format(metadata, response))
+                .collect(ImmutableList.toImmutableList());
     }
 }

--- a/src/main/java/com/gorlah/kappabot/function/command/CommandAdapter.java
+++ b/src/main/java/com/gorlah/kappabot/function/command/CommandAdapter.java
@@ -26,6 +26,13 @@ public interface CommandAdapter {
     String getSource();
 
     /**
+     * Gets the output content type that this adapter supports.
+     *
+     * @return the supported output content type
+     */
+    String getContentType();
+
+    /**
      * Returns the enabled status of this command adapter. When the command adapter is enabled, it may be used to
      * handle incoming requests from a certain source with a certain command prefix.
      *

--- a/src/main/java/com/gorlah/kappabot/function/command/CommandAdapterFinder.java
+++ b/src/main/java/com/gorlah/kappabot/function/command/CommandAdapterFinder.java
@@ -1,0 +1,32 @@
+package com.gorlah.kappabot.function.command;
+
+import com.gorlah.kappabot.function.BotRequestMetadata;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class CommandAdapterFinder {
+
+    private final Set<CommandAdapter> commandAdapters;
+
+    public Optional<CommandAdapter> findAdapter(BotRequestMetadata metadata) {
+        return commandAdapters.stream()
+                .filter(CommandAdapter::isEnabled)
+                .filter(adapter -> adapter.getSource().equals(metadata.getSource()))
+                .filter(adapter -> shouldProcess(metadata, adapter.getCommandPrefix()))
+                .findFirst();
+    }
+
+    private boolean shouldProcess(BotRequestMetadata metadata, String commandPrefix) {
+        return metadata.getMessage().length() > commandPrefix.length()
+                && messageBeginsWithCommandPrefix(metadata.getMessage(), commandPrefix);
+    }
+
+    private boolean messageBeginsWithCommandPrefix(String message, String commandPrefix) {
+        return commandPrefix.equalsIgnoreCase(message.substring(0, commandPrefix.length()));
+    }
+}

--- a/src/main/java/com/gorlah/kappabot/function/command/CommandFunction.java
+++ b/src/main/java/com/gorlah/kappabot/function/command/CommandFunction.java
@@ -6,7 +6,7 @@ import com.gorlah.kappabot.command.CommandProcessor;
 import com.gorlah.kappabot.function.BotFunction;
 import com.gorlah.kappabot.function.BotRequestMetadata;
 import com.gorlah.kappabot.function.response.BotResponse;
-import com.gorlah.kappabot.function.response.ImmutableBotResponse;
+import com.gorlah.kappabot.function.response.BotResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -27,6 +27,6 @@ public class CommandFunction implements BotFunction {
                 .map(commandPrefix -> commandPayloadBuilder.parseMessageAndBuild(metadata, commandPrefix))
                 .map(commandProcessor::process)
                 .map(Strings::nullToEmpty)
-                .map(message -> ImmutableBotResponse.of("text/markdown", message));
+                .map(BotResponses::fromMarkdown);
     }
 }

--- a/src/main/java/com/gorlah/kappabot/function/command/CommandFunction.java
+++ b/src/main/java/com/gorlah/kappabot/function/command/CommandFunction.java
@@ -1,46 +1,32 @@
 package com.gorlah.kappabot.function.command;
 
+import com.google.common.base.Strings;
 import com.gorlah.kappabot.command.CommandPayloadBuilder;
 import com.gorlah.kappabot.command.CommandProcessor;
 import com.gorlah.kappabot.function.BotFunction;
 import com.gorlah.kappabot.function.BotRequestMetadata;
+import com.gorlah.kappabot.function.response.BotResponse;
+import com.gorlah.kappabot.function.response.ImmutableBotResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
-import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
 public class CommandFunction implements BotFunction {
 
-    private final Set<CommandAdapter> commandAdapters;
-
     private final CommandPayloadBuilder commandPayloadBuilder;
     private final CommandProcessor commandProcessor;
+    private final CommandAdapterFinder commandAdapterFinder;
 
     @Override
-    public Optional<String> process(BotRequestMetadata metadata) {
-        return findAdapter(metadata)
+    public Optional<BotResponse> process(BotRequestMetadata metadata) {
+        return commandAdapterFinder.findAdapter(metadata)
                 .map(CommandAdapter::getCommandPrefix)
                 .map(commandPrefix -> commandPayloadBuilder.parseMessageAndBuild(metadata, commandPrefix))
-                .map(commandProcessor::process);
-    }
-
-    private Optional<CommandAdapter> findAdapter(BotRequestMetadata metadata) {
-        return commandAdapters.stream()
-                .filter(CommandAdapter::isEnabled)
-                .filter(adapter -> adapter.getSource().equals(metadata.getSource()))
-                .filter(adapter -> shouldProcess(metadata, adapter.getCommandPrefix()))
-                .findFirst();
-    }
-
-    private boolean shouldProcess(BotRequestMetadata metadata, String commandPrefix) {
-        return metadata.getMessage().length() > commandPrefix.length()
-                && messageBeginsWithCommandPrefix(metadata.getMessage(), commandPrefix);
-    }
-
-    private boolean messageBeginsWithCommandPrefix(String message, String commandPrefix) {
-        return commandPrefix.equalsIgnoreCase(message.substring(0, commandPrefix.length()));
+                .map(commandProcessor::process)
+                .map(Strings::nullToEmpty)
+                .map(message -> ImmutableBotResponse.of("text/markdown", message));
     }
 }

--- a/src/main/java/com/gorlah/kappabot/function/response/BotResponse.java
+++ b/src/main/java/com/gorlah/kappabot/function/response/BotResponse.java
@@ -1,0 +1,7 @@
+package com.gorlah.kappabot.function.response;
+
+public interface BotResponse {
+
+    String getContentType();
+    String getMessage();
+}

--- a/src/main/java/com/gorlah/kappabot/function/response/BotResponses.java
+++ b/src/main/java/com/gorlah/kappabot/function/response/BotResponses.java
@@ -1,0 +1,22 @@
+package com.gorlah.kappabot.function.response;
+
+import static com.gorlah.kappabot.util.StandardContentTypes.HTML;
+import static com.gorlah.kappabot.util.StandardContentTypes.MARKDOWN;
+import static com.gorlah.kappabot.util.StandardContentTypes.PLAIN_TEXT;
+
+public class BotResponses {
+
+    private BotResponses() {}
+
+    public static BotResponse fromMarkdown(String markdown) {
+        return ImmutableBotResponse.of(MARKDOWN, markdown);
+    }
+
+    public static BotResponse fromPlainText(String text) {
+        return ImmutableBotResponse.of(PLAIN_TEXT, text);
+    }
+
+    public static BotResponse fromHtml(String html) {
+        return ImmutableBotResponse.of(HTML, html);
+    }
+}

--- a/src/main/java/com/gorlah/kappabot/function/response/ImmutableBotResponse.java
+++ b/src/main/java/com/gorlah/kappabot/function/response/ImmutableBotResponse.java
@@ -1,0 +1,10 @@
+package com.gorlah.kappabot.function.response;
+
+import lombok.Value;
+
+@Value(staticConstructor = "of")
+public class ImmutableBotResponse implements BotResponse {
+
+    String contentType;
+    String message;
+}

--- a/src/main/java/com/gorlah/kappabot/function/response/formatter/BotResponseFormatter.java
+++ b/src/main/java/com/gorlah/kappabot/function/response/formatter/BotResponseFormatter.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Component;
 
 import java.util.Optional;
 
+import static com.gorlah.kappabot.util.StandardContentTypes.PLAIN_TEXT;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -35,7 +37,7 @@ public class BotResponseFormatter {
                             "Unable to convert to content type {} for adapter {}.",
                             adapter.getContentType(),
                             adapter.getSource());
-                    return responseFormatter.format(response, "text/plain");
+                    return responseFormatter.format(response, PLAIN_TEXT);
                 });
     }
 }

--- a/src/main/java/com/gorlah/kappabot/function/response/formatter/BotResponseFormatter.java
+++ b/src/main/java/com/gorlah/kappabot/function/response/formatter/BotResponseFormatter.java
@@ -1,0 +1,41 @@
+package com.gorlah.kappabot.function.response.formatter;
+
+import com.gorlah.kappabot.function.BotRequestMetadata;
+import com.gorlah.kappabot.function.command.CommandAdapter;
+import com.gorlah.kappabot.function.command.CommandAdapterFinder;
+import com.gorlah.kappabot.function.response.BotResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.util.Optionals;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BotResponseFormatter {
+
+    private final CommandAdapterFinder commandAdapterFinder;
+    private final ResponseFormatter responseFormatter;
+
+    public String format(BotRequestMetadata request, BotResponse response) {
+        return commandAdapterFinder.findAdapter(request).stream()
+                .map(adapter -> format(response, adapter))
+                .flatMap(Optional::stream)
+                .findFirst()
+                .orElse(response.getMessage());
+    }
+
+    private Optional<String> format(BotResponse response, CommandAdapter adapter) {
+        return Optionals.firstNonEmpty(
+                () -> responseFormatter.format(response, adapter.getContentType()),
+                () -> {
+                    log.warn(
+                            "Unable to convert to content type {} for adapter {}.",
+                            adapter.getContentType(),
+                            adapter.getSource());
+                    return responseFormatter.format(response, "text/plain");
+                });
+    }
+}

--- a/src/main/java/com/gorlah/kappabot/function/response/formatter/DefaultResponseFormatter.java
+++ b/src/main/java/com/gorlah/kappabot/function/response/formatter/DefaultResponseFormatter.java
@@ -1,0 +1,27 @@
+package com.gorlah.kappabot.function.response.formatter;
+
+import com.gorlah.kappabot.function.response.BotResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Provider;
+import java.util.Optional;
+import java.util.Set;
+
+@Primary
+@Component
+@RequiredArgsConstructor
+class DefaultResponseFormatter implements ResponseFormatter {
+
+    private final Provider<Set<ResponseFormatter>> responseFormatters;
+
+    @Override
+    public Optional<String> format(BotResponse response, String contentType) {
+        return responseFormatters.get().stream()
+                .filter(formatter -> formatter != this)
+                .map(formatter -> formatter.format(response, contentType))
+                .flatMap(Optional::stream)
+                .findFirst();
+    }
+}

--- a/src/main/java/com/gorlah/kappabot/function/response/formatter/HtmlToPlainTextResponseFormatter.java
+++ b/src/main/java/com/gorlah/kappabot/function/response/formatter/HtmlToPlainTextResponseFormatter.java
@@ -1,0 +1,24 @@
+package com.gorlah.kappabot.function.response.formatter;
+
+import com.gorlah.kappabot.function.response.BotResponse;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+@Component
+class HtmlToPlainTextResponseFormatter implements ResponseFormatter {
+
+    @Override
+    public Optional<String> format(BotResponse response, String contentType) {
+        return Stream.of(response)
+                .filter(resp -> resp.getContentType().equals("text/html"))
+                .filter(resp -> contentType.equals("text/plain"))
+                .map(BotResponse::getMessage)
+                .map(Jsoup::parse)
+                .map(Document::text)
+                .findFirst();
+    }
+}

--- a/src/main/java/com/gorlah/kappabot/function/response/formatter/HtmlToPlainTextResponseFormatter.java
+++ b/src/main/java/com/gorlah/kappabot/function/response/formatter/HtmlToPlainTextResponseFormatter.java
@@ -8,14 +8,17 @@ import org.springframework.stereotype.Component;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static com.gorlah.kappabot.util.StandardContentTypes.HTML;
+import static com.gorlah.kappabot.util.StandardContentTypes.PLAIN_TEXT;
+
 @Component
 class HtmlToPlainTextResponseFormatter implements ResponseFormatter {
 
     @Override
     public Optional<String> format(BotResponse response, String contentType) {
         return Stream.of(response)
-                .filter(resp -> resp.getContentType().equals("text/html"))
-                .filter(resp -> contentType.equals("text/plain"))
+                .filter(resp -> HTML.equals(resp.getContentType()))
+                .filter(resp -> PLAIN_TEXT.equals(contentType))
                 .map(BotResponse::getMessage)
                 .map(Jsoup::parse)
                 .map(Document::text)

--- a/src/main/java/com/gorlah/kappabot/function/response/formatter/MarkdownToHtmlResponseFormatter.java
+++ b/src/main/java/com/gorlah/kappabot/function/response/formatter/MarkdownToHtmlResponseFormatter.java
@@ -1,0 +1,27 @@
+package com.gorlah.kappabot.function.response.formatter;
+
+import com.gorlah.kappabot.function.response.BotResponse;
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+@Component
+class MarkdownToHtmlResponseFormatter implements ResponseFormatter {
+
+    private final Parser parser = Parser.builder().build();
+    private final HtmlRenderer renderer = HtmlRenderer.builder().build();
+
+    @Override
+    public Optional<String> format(BotResponse response, String contentType) {
+        return Stream.of(response)
+                .filter(resp -> resp.getContentType().equals("text/markdown"))
+                .filter(resp -> contentType.equals("text/html"))
+                .map(BotResponse::getMessage)
+                .map(parser::parse)
+                .map(renderer::render)
+                .findFirst();
+    }
+}

--- a/src/main/java/com/gorlah/kappabot/function/response/formatter/MarkdownToHtmlResponseFormatter.java
+++ b/src/main/java/com/gorlah/kappabot/function/response/formatter/MarkdownToHtmlResponseFormatter.java
@@ -8,6 +8,9 @@ import org.springframework.stereotype.Component;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static com.gorlah.kappabot.util.StandardContentTypes.HTML;
+import static com.gorlah.kappabot.util.StandardContentTypes.MARKDOWN;
+
 @Component
 class MarkdownToHtmlResponseFormatter implements ResponseFormatter {
 
@@ -17,8 +20,8 @@ class MarkdownToHtmlResponseFormatter implements ResponseFormatter {
     @Override
     public Optional<String> format(BotResponse response, String contentType) {
         return Stream.of(response)
-                .filter(resp -> resp.getContentType().equals("text/markdown"))
-                .filter(resp -> contentType.equals("text/html"))
+                .filter(resp -> MARKDOWN.equals(resp.getContentType()))
+                .filter(resp -> HTML.equals(contentType))
                 .map(BotResponse::getMessage)
                 .map(parser::parse)
                 .map(renderer::render)

--- a/src/main/java/com/gorlah/kappabot/function/response/formatter/MarkdownToPlainTextResponseFormatter.java
+++ b/src/main/java/com/gorlah/kappabot/function/response/formatter/MarkdownToPlainTextResponseFormatter.java
@@ -8,14 +8,17 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.gorlah.kappabot.util.StandardContentTypes.MARKDOWN;
+import static com.gorlah.kappabot.util.StandardContentTypes.PLAIN_TEXT;
+
 @Component
 class MarkdownToPlainTextResponseFormatter implements ResponseFormatter {
 
     @Override
     public Optional<String> format(BotResponse response, String contentType) {
         return Stream.of(response)
-                .filter(resp -> resp.getContentType().equals("text/markdown"))
-                .filter(resp -> contentType.equals("text/plain"))
+                .filter(resp -> MARKDOWN.equals(resp.getContentType()))
+                .filter(resp -> PLAIN_TEXT.equals(contentType))
                 .map(resp -> convertToPlainText(resp.getMessage()))
                 .findFirst();
     }

--- a/src/main/java/com/gorlah/kappabot/function/response/formatter/MarkdownToPlainTextResponseFormatter.java
+++ b/src/main/java/com/gorlah/kappabot/function/response/formatter/MarkdownToPlainTextResponseFormatter.java
@@ -1,0 +1,34 @@
+package com.gorlah.kappabot.function.response.formatter;
+
+import com.google.common.base.Splitter;
+import com.gorlah.kappabot.function.response.BotResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Component
+class MarkdownToPlainTextResponseFormatter implements ResponseFormatter {
+
+    @Override
+    public Optional<String> format(BotResponse response, String contentType) {
+        return Stream.of(response)
+                .filter(resp -> resp.getContentType().equals("text/markdown"))
+                .filter(resp -> contentType.equals("text/plain"))
+                .map(resp -> convertToPlainText(resp.getMessage()))
+                .findFirst();
+    }
+
+    private String convertToPlainText(String markdown) {
+        return Splitter.on('\n').splitToStream(
+                markdown.replaceAll("`", "")
+                        .replaceAll("\\*", "")
+                        .replaceAll("_", "")
+                        .replaceAll("#", ""))
+                .map(String::trim)
+                .filter(line -> !line.isBlank())
+                .filter(line -> !line.replaceAll("-", "").isBlank())
+                .collect(Collectors.joining("\n"));
+    }
+}

--- a/src/main/java/com/gorlah/kappabot/function/response/formatter/PlainTextToMarkdownResponseFormatter.java
+++ b/src/main/java/com/gorlah/kappabot/function/response/formatter/PlainTextToMarkdownResponseFormatter.java
@@ -1,0 +1,20 @@
+package com.gorlah.kappabot.function.response.formatter;
+
+import com.gorlah.kappabot.function.response.BotResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+@Component
+class PlainTextToMarkdownResponseFormatter implements ResponseFormatter {
+
+    @Override
+    public Optional<String> format(BotResponse response, String contentType) {
+        return Stream.of(response)
+                .filter(resp -> resp.getContentType().equals("text/plain"))
+                .filter(resp -> contentType.equals("text/markdown"))
+                .map(BotResponse::getMessage)
+                .findFirst();
+    }
+}

--- a/src/main/java/com/gorlah/kappabot/function/response/formatter/PlainTextToMarkdownResponseFormatter.java
+++ b/src/main/java/com/gorlah/kappabot/function/response/formatter/PlainTextToMarkdownResponseFormatter.java
@@ -6,14 +6,17 @@ import org.springframework.stereotype.Component;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static com.gorlah.kappabot.util.StandardContentTypes.MARKDOWN;
+import static com.gorlah.kappabot.util.StandardContentTypes.PLAIN_TEXT;
+
 @Component
 class PlainTextToMarkdownResponseFormatter implements ResponseFormatter {
 
     @Override
     public Optional<String> format(BotResponse response, String contentType) {
         return Stream.of(response)
-                .filter(resp -> resp.getContentType().equals("text/plain"))
-                .filter(resp -> contentType.equals("text/markdown"))
+                .filter(resp -> PLAIN_TEXT.equals(resp.getContentType()))
+                .filter(resp -> MARKDOWN.equals(contentType))
                 .map(BotResponse::getMessage)
                 .findFirst();
     }

--- a/src/main/java/com/gorlah/kappabot/function/response/formatter/ResponseFormatter.java
+++ b/src/main/java/com/gorlah/kappabot/function/response/formatter/ResponseFormatter.java
@@ -5,6 +5,7 @@ import com.gorlah.kappabot.function.response.BotResponse;
 import java.util.Optional;
 
 
+@FunctionalInterface
 public interface ResponseFormatter {
 
     /**

--- a/src/main/java/com/gorlah/kappabot/function/response/formatter/ResponseFormatter.java
+++ b/src/main/java/com/gorlah/kappabot/function/response/formatter/ResponseFormatter.java
@@ -1,0 +1,18 @@
+package com.gorlah.kappabot.function.response.formatter;
+
+import com.gorlah.kappabot.function.response.BotResponse;
+
+import java.util.Optional;
+
+
+public interface ResponseFormatter {
+
+    /**
+     * Attempts to format a bot's response to the specified content type.
+     *
+     * @param response a response from the bot
+     * @param contentType the desired output content type
+     * @return the formatted message if the formatter was able to convert it
+     */
+    Optional<String> format(BotResponse response, String contentType);
+}

--- a/src/main/java/com/gorlah/kappabot/function/response/formatter/SimpleResponseFormatter.java
+++ b/src/main/java/com/gorlah/kappabot/function/response/formatter/SimpleResponseFormatter.java
@@ -1,0 +1,20 @@
+package com.gorlah.kappabot.function.response.formatter;
+
+import com.gorlah.kappabot.function.response.BotResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * A simple formatter for messages that are already in the correct format.
+ */
+@Component
+class SimpleResponseFormatter implements ResponseFormatter {
+
+    @Override
+    public Optional<String> format(BotResponse response, String contentType) {
+        return Optional.of(response)
+                .filter(resp -> resp.getContentType().equals(contentType))
+                .map(BotResponse::getMessage);
+    }
+}

--- a/src/main/java/com/gorlah/kappabot/function/slashdot/MobileSlashdotTitleFunction.java
+++ b/src/main/java/com/gorlah/kappabot/function/slashdot/MobileSlashdotTitleFunction.java
@@ -3,7 +3,7 @@ package com.gorlah.kappabot.function.slashdot;
 import com.gorlah.kappabot.function.BotFunction;
 import com.gorlah.kappabot.function.BotRequestMetadata;
 import com.gorlah.kappabot.function.response.BotResponse;
-import com.gorlah.kappabot.function.response.ImmutableBotResponse;
+import com.gorlah.kappabot.function.response.BotResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -23,7 +23,7 @@ public class MobileSlashdotTitleFunction implements BotFunction {
                     .map(title -> "> " + title)
                     .collect(Collectors.joining("\n"));
             if (!response.trim().isEmpty()) {
-                return Optional.of(ImmutableBotResponse.of("text/markdown", response));
+                return Optional.of(BotResponses.fromMarkdown(response));
             }
         }
         return Optional.empty();

--- a/src/main/java/com/gorlah/kappabot/function/slashdot/MobileSlashdotTitleFunction.java
+++ b/src/main/java/com/gorlah/kappabot/function/slashdot/MobileSlashdotTitleFunction.java
@@ -2,6 +2,8 @@ package com.gorlah.kappabot.function.slashdot;
 
 import com.gorlah.kappabot.function.BotFunction;
 import com.gorlah.kappabot.function.BotRequestMetadata;
+import com.gorlah.kappabot.function.response.BotResponse;
+import com.gorlah.kappabot.function.response.ImmutableBotResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -15,13 +17,13 @@ public class MobileSlashdotTitleFunction implements BotFunction {
     private final MobileSlashdotTitleParser slashdotParser;
 
     @Override
-    public Optional<String> process(BotRequestMetadata metadata) {
+    public Optional<BotResponse> process(BotRequestMetadata metadata) {
         if (slashdotParser.containsMobileSlashdotUrl(metadata.getMessage())) {
             var response = slashdotParser.getTitles(metadata.getMessage()).stream()
                     .map(title -> "> " + title)
                     .collect(Collectors.joining("\n"));
             if (!response.trim().isEmpty()) {
-                return Optional.of(response);
+                return Optional.of(ImmutableBotResponse.of("text/markdown", response));
             }
         }
         return Optional.empty();

--- a/src/main/java/com/gorlah/kappabot/integration/discord/DiscordCommandAdapter.java
+++ b/src/main/java/com/gorlah/kappabot/integration/discord/DiscordCommandAdapter.java
@@ -1,6 +1,7 @@
 package com.gorlah.kappabot.integration.discord;
 
 import com.gorlah.kappabot.function.command.CommandAdapter;
+import com.gorlah.kappabot.util.StandardContentTypes;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -22,7 +23,7 @@ public class DiscordCommandAdapter implements CommandAdapter {
 
     @Override
     public String getContentType() {
-        return "text/markdown";
+        return StandardContentTypes.MARKDOWN;
     }
 
     @Override

--- a/src/main/java/com/gorlah/kappabot/integration/discord/DiscordCommandAdapter.java
+++ b/src/main/java/com/gorlah/kappabot/integration/discord/DiscordCommandAdapter.java
@@ -21,6 +21,11 @@ public class DiscordCommandAdapter implements CommandAdapter {
     }
 
     @Override
+    public String getContentType() {
+        return "text/markdown";
+    }
+
+    @Override
     public boolean isEnabled() {
         return discordIntegration.isEnabled();
     }

--- a/src/main/java/com/gorlah/kappabot/rest/CommandService.java
+++ b/src/main/java/com/gorlah/kappabot/rest/CommandService.java
@@ -11,7 +11,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RestController
@@ -23,7 +25,7 @@ public class CommandService {
     @PostMapping("/command/run")
     public String runCommand(@RequestBody CommandRequest request) {
         validate(request);
-        return formatResponse(functionProcessor.process(request), request.getAuthor());
+        return formatResponses(functionProcessor.process(request), request.getAuthor());
     }
 
     private void validate(CommandRequest request) {
@@ -33,6 +35,12 @@ public class CommandService {
                 || Strings.isNullOrEmpty(request.getSource())) {
             throw new RuntimeException();
         }
+    }
+
+    private String formatResponses(List<String> responses, String author) {
+        return responses.stream()
+                .map(response -> formatResponse(response, author))
+                .collect(Collectors.joining("\n-----------------------\n"));
     }
 
     private String formatResponse(String response, String author) {

--- a/src/main/java/com/gorlah/kappabot/util/StandardContentTypes.java
+++ b/src/main/java/com/gorlah/kappabot/util/StandardContentTypes.java
@@ -1,0 +1,10 @@
+package com.gorlah.kappabot.util;
+
+public class StandardContentTypes {
+
+    public static final String PLAIN_TEXT = "text/plain";
+    public static final String MARKDOWN = "text/markdown";
+    public static final String HTML = "text/html";
+
+    private StandardContentTypes() {}
+}


### PR DESCRIPTION
Part 2 of changes that are necessary to support IRC.

There are several significant changes here:
- Enhanced responses from command execution to include the content type of the response. The new response type is `BotResponse`.
- Enhanced `FunctionProcessor` to allow multiple functions to respond to each command individually.
- Enhanced `CommandAdapter` such that an adapter may specify the desired output content type for responses to messages handled by that adapter.
- Created `ResponseFormatter` family of classes that handle converting between message formats, specifically converting whatever the `BotFunction` responds with into whatever the receiving `CommandAdapter` expects, gracefully falling back if such conversion is not possible. New `ResponseFormatter`s may be added as `@Component`s and will automatically be detected and used as necessary.

For now all commands (meaning just everything operating downstream of `CommandFunction`) are expected to return Markdown or plain text responses. This could be enhanced at a later point if needed to allow those commands to return the richer `BotResponse`.